### PR TITLE
[feature] 기존 initFiles 성격의 기능 복사/위치 변경 + buffer/ 도 initFiles 하도록 기능 추가

### DIFF
--- a/SsdDriver/build.gradle.kts
+++ b/SsdDriver/build.gradle.kts
@@ -28,9 +28,8 @@ java {
 }
 
 application {
-    mainClass.set("Ssd") // 🔁 여기를 실제 메인 클래스 이름으로 바꾸세요
+    mainClass.set("Main") // 🔁 여기를 실제 메인 클래스 이름으로 바꾸세요
 }
-
 
 tasks.named<Jar>("jar") {
     manifest {

--- a/SsdDriver/src/main/java/SsdConstants.java
+++ b/SsdDriver/src/main/java/SsdConstants.java
@@ -7,5 +7,7 @@ public final class SsdConstants {
     public static final String SSD_NAND_FILE = "ssd_nand.txt";
     public static final String OUTPUT_FILE_PATH = "ssd_output.txt";
     public static final int BLOCK_SIZE = 10;
+    public static final int BUFFER_SIZE = 5;
+    public static final String DEFAULT_DATA = "0x00000000";
     public static final String ERROR = "ERROR";
 }

--- a/SsdDriver/src/test/java/SsdTest.java
+++ b/SsdDriver/src/test/java/SsdTest.java
@@ -1,0 +1,58 @@
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+class SsdTest {
+    @BeforeEach
+    void setUp() {
+        cleanFiles();
+    }
+
+    private void cleanFiles() {
+        // Clean up created files and directories before each test
+        new File(SsdConstants.SSD_NAND_FILE).delete();
+        new File(SsdConstants.OUTPUT_FILE_PATH).delete();
+        File bufferDir = new File("buffer");
+        if (bufferDir.exists()) {
+            for (File file : bufferDir.listFiles()) {
+                file.delete();
+            }
+            bufferDir.delete();
+        }
+    }
+
+    @Test
+    void initFiles() {
+        Ssd ssd = spy(new Ssd());
+
+        try {
+            ssd.initFiles();
+        } catch (Exception e) {
+            fail("Initialization failed: " + e.getMessage());
+        }
+
+        // Check if the SSD NAND file exists
+        assertTrue(new File(SsdConstants.SSD_NAND_FILE).exists(), "SSD NAND file should exist");
+
+        // Check if the output file is created
+        assertTrue(new File(SsdConstants.OUTPUT_FILE_PATH).exists(), "Output file should exist");
+
+        // Check if buffer directory is created
+        assertTrue(new File("buffer").exists(), "Buffer directory should exist");
+
+        // Check if buffer files are created
+        for (int bufferNum = 1; bufferNum <= SsdConstants.BUFFER_SIZE; bufferNum++) {
+            String bufferPrefix = bufferNum + "_";
+            File[] bufferFiles = new File("buffer").listFiles((dir, name) -> name.startsWith(bufferPrefix));
+            assertNotNull(bufferFiles, "Buffer files should not be null");
+            assertTrue(bufferFiles.length > 0, "Buffer files should exist for buffer number: " + bufferNum);
+        }
+    }
+
+}


### PR DESCRIPTION
## 📌 제목 (Title)
**[feature] 기존 initFiles 성격의 기능 복사/위치 변경 + buffer/ 도 initFiles 하도록 기능 추가**

---

## ✨ 주요 변경사항 (What’s changed?)
- SsdReader, SsdWriter에 작성된 기능을 단순 복사하여 Ssd의 `initFiles`로 옮겼습니다.
- buffer/ 에 대해서도 init하도록 기능 추가했습니다.
- 리팩토링은 이어서 진행하겠습니다. 아직 SsdReader, SsdWriter에 남아있는 건 그 때 삭제하겠습니다.

---

## 🧪 테스트 (Test Plan)

- [x] 테스트 코드 작성 또는 기존 테스트 통과 확인
  - `ssdTest.java` 파일이 추가됩니다.
- [x] 직접 실행해본 결과 스크린샷 or 설명 포함 (선택)
![image](https://github.com/user-attachments/assets/b6eb11a8-8348-4a74-85ad-d115afd7cb4e)
  - Before
  ![image](https://github.com/user-attachments/assets/5c98559b-a9a6-4b27-a1fa-59e5b742869c)
  - After
  ![image](https://github.com/user-attachments/assets/360a5f55-4dc4-4a18-add8-d4c39dbabce5)

---


## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 작동함
- [x] 스타일 가이드/코딩 컨벤션을 따름
- [x] 필요한 경우 문서(README 등)를 업데이트함
- [x] 리뷰어가 이해하기 쉬운 설명이 포함됨


## 💬 기타 (Additional Notes)
- `initFiles`를 private으로 두자니... test에서 호출이 안 되어서;; package-private으로 두었습니다. 의견 부탁드려요~
![image](https://github.com/user-attachments/assets/8511399c-d2b0-4d49-8e5e-0d10689a240b)
