### PR TITLE
[feature] erase 유효성 검사 추가

### DIFF
--- a/SsdDriver/src/main/java/Ssd.java
+++ b/SsdDriver/src/main/java/Ssd.java
@@ -10,6 +10,7 @@ public class Ssd {
     public static final String DATA_FORMAT = "^0x[0-9A-Fa-f]{8}$";
     public static final String WRITE_COMMAND = "W";
     public static final String READ_COMMAND = "R";
+    public static final String ERASE_COMMAND = "E";
     public static final int ARGUMENT_COMMAND_INDEX = 0;
     public static final int ARGUMENT_ADDRESS_INDEX = 1;
     public static final int ARGUMENT_DATA_INDEX = 2;
@@ -34,6 +35,8 @@ public class Ssd {
             processWriteCommand(args);
         } else if (isReadCommand(args)) {
             processReadCommand(args);
+        } else if (isEraseCommand(args)) {
+            processEraseCommand(args);
         }
     }
 
@@ -91,6 +94,18 @@ public class Ssd {
         }
     }
 
+    private void processEraseCommand(String[] args) {
+        SsdEraser eraser = new SsdEraser();
+
+        int LBA = Integer.parseInt(args[ARGUMENT_ADDRESS_INDEX]);
+        int size = Integer.parseInt(args[ARGUMENT_DATA_INDEX]);
+        try {
+            eraser.erase(LBA, size);
+        } catch (IOException e) {
+            // ignore
+        }
+    }
+
     private boolean isWriteCommand(String[] args) {
         return WRITE_COMMAND.equals(args[ARGUMENT_COMMAND_INDEX]);
     }
@@ -99,17 +114,30 @@ public class Ssd {
         return READ_COMMAND.equals(args[ARGUMENT_COMMAND_INDEX]);
     }
 
+    private boolean isEraseCommand(String[] args) {
+        return ERASE_COMMAND.equals(args[ARGUMENT_COMMAND_INDEX]);
+    }
+
     private boolean checkPreCondition(String[] args) {
         if (!isValidArgumentCount(args)) return false;
         if (!isValidCommand(args[ARGUMENT_COMMAND_INDEX])) return false;
         if (!isValidAddressRange(args[ARGUMENT_ADDRESS_INDEX])) return false;
         if (!isValidDataForWrite(args)) return false;
+        if (!isValidDataForErase(args)) return false;
+
         return true;
     }
 
     private boolean isValidDataForWrite(String[] args) {
-        if (isReadCommand(args)) return true;
+        if (isReadCommand(args) || isEraseCommand(args)) return true;
         return isWriteCommand(args) && args[ARGUMENT_DATA_INDEX].matches(DATA_FORMAT);
+    }
+
+    private boolean isValidDataForErase(String[] args) {
+        if (isReadCommand(args) || isWriteCommand(args)) return true;
+        if (Integer.parseInt(args[ARGUMENT_DATA_INDEX]) < 0 || Integer.parseInt(args[ARGUMENT_DATA_INDEX]) > 10) return false;
+        int lastLBA = Integer.parseInt(args[ARGUMENT_ADDRESS_INDEX]) + Integer.parseInt(args[ARGUMENT_DATA_INDEX]) - 1;
+        return isEraseCommand(args) && isValidAddressRange(Integer.toString(lastLBA));
     }
 
     private boolean isValidAddressRange(String address) {
@@ -121,7 +149,7 @@ public class Ssd {
     }
 
     private boolean isValidCommand(String command) {
-        return WRITE_COMMAND.equals(command) || READ_COMMAND.equals(command);
+        return WRITE_COMMAND.equals(command) || READ_COMMAND.equals(command) || ERASE_COMMAND.equals(command);
     }
 
     private boolean isValidArgumentCount(String[] args) {

--- a/SsdDriver/src/test/java/SsdEraserTest.java
+++ b/SsdDriver/src/test/java/SsdEraserTest.java
@@ -20,7 +20,7 @@ class SsdEraserTest {
     }
 
     @Test
-    void 다섯개_write_직후_세개_일부_erase() {
+    void 다섯개_write_직후_세개_일부_erase_ssdEraserTest_erase() {
         SsdReader reader = new SsdReader();
         SsdWriter writer = new SsdWriter();
         SsdEraser eraser = new SsdEraser();

--- a/SsdDriver/src/test/java/SsdTest.java
+++ b/SsdDriver/src/test/java/SsdTest.java
@@ -32,7 +32,7 @@ class SsdTest {
     }
 
     @Test
-    void initFiles() {
+    void initFiles_뒤_파일_정상_초기화_및_생성_확인() {
         Ssd ssd = spy(new Ssd());
 
         try {
@@ -60,7 +60,7 @@ class SsdTest {
     }
 
     @Test
-    void SsdEraserTest와_같은_테스트를_processCommand로_진행() {
+    void 다섯개_write_직후_세개_일부_erase_ssd_processCommand() {
         SsdReader reader = new SsdReader();
         SsdWriter writer = new SsdWriter();
         Ssd ssd = new Ssd();
@@ -93,7 +93,7 @@ class SsdTest {
     }
 
     @Test
-    void processCommand_삭제_유효성검사_걸러내는지_확인() {
+    void 삭제_args_유효성검사_정상1() {
         Ssd ssd = new Ssd();
         String output;
 
@@ -102,22 +102,77 @@ class SsdTest {
             output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
             assertThat(output).isEqualTo("");
 
-            ssd.processCommand(new String[]{"E", "0", "-1"});
-            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
-            assertThat(output).isEqualTo(SsdConstants.ERROR); // 음수개 못 지움
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
+    @Test
+    void 삭제_args_유효성검사_정상2() {
+        Ssd ssd = new Ssd();
+        String output;
+
+        try {
             ssd.processCommand(new String[]{"E", "99", "0"});
             output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
             assertThat(output).isEqualTo("");
 
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void 삭제_args_유효성검사_정상3() {
+        Ssd ssd = new Ssd();
+        String output;
+
+        try {
             ssd.processCommand(new String[]{"E", "99", "1"});
             output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
             assertThat(output).isEqualTo("");
 
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void 삭제_args_유효성검사_비정상_음수개() {
+        Ssd ssd = new Ssd();
+        String output;
+
+        try {
+            ssd.processCommand(new String[]{"E", "0", "-1"});
+            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+            assertThat(output).isEqualTo(SsdConstants.ERROR); // 음수개 못 지움
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void 삭제_args_유효성검사_비정상_10개_초과() {
+        Ssd ssd = new Ssd();
+        String output;
+
+        try {
             ssd.processCommand(new String[]{"E", "91", "20"});
             output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
             assertThat(output).isEqualTo(SsdConstants.ERROR); // 10개 초과 못 지움
 
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void 삭제_args_유효성검사_비정상_범위_초과() {
+        Ssd ssd = new Ssd();
+        String output;
+
+        try {
             ssd.processCommand(new String[]{"E", "95", "10"});
             output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
             assertThat(output).isEqualTo(SsdConstants.ERROR); // 99 LBA 넘어서 못 자움
@@ -125,6 +180,5 @@ class SsdTest {
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
-
     }
 }

--- a/SsdDriver/src/test/java/SsdTest.java
+++ b/SsdDriver/src/test/java/SsdTest.java
@@ -3,7 +3,11 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -55,4 +59,72 @@ class SsdTest {
         }
     }
 
+    @Test
+    void SsdEraserTest와_같은_테스트를_processCommand로_진행() {
+        SsdReader reader = new SsdReader();
+        SsdWriter writer = new SsdWriter();
+        Ssd ssd = new Ssd();
+
+        try {
+            String expected = "0x12345678";
+            for (int i = 0; i < 5; i++) {
+                writer.write(i, expected);
+                reader.read(i);
+                String output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+                assertThat(output).isEqualTo(expected);
+            }
+
+            ssd.processCommand(new String[]{"E", "1", "3"});
+            for (int i : new int[]{1, 2, 3}) {
+                reader.read(i);
+                String output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+                assertThat(output).isEqualTo(SsdConstants.DEFAULT_DATA);
+            }
+
+            for (int i : new int[]{0, 4}) {
+                reader.read(i);
+                String output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+                assertThat(output).isEqualTo(expected);
+            }
+
+        } catch (IOException e) {
+            fail("Erase operation failed: " + e.getMessage());
+        }
+    }
+
+    @Test
+    void processCommand_삭제_유효성검사_걸러내는지_확인() {
+        Ssd ssd = new Ssd();
+        String output;
+
+        try {
+            ssd.processCommand(new String[]{"E", "0", "10"});
+            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+            assertThat(output).isEqualTo("");
+
+            ssd.processCommand(new String[]{"E", "0", "-1"});
+            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+            assertThat(output).isEqualTo(SsdConstants.ERROR); // 음수개 못 지움
+
+            ssd.processCommand(new String[]{"E", "99", "0"});
+            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+            assertThat(output).isEqualTo("");
+
+            ssd.processCommand(new String[]{"E", "99", "1"});
+            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+            assertThat(output).isEqualTo("");
+
+            ssd.processCommand(new String[]{"E", "91", "20"});
+            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+            assertThat(output).isEqualTo(SsdConstants.ERROR); // 10개 초과 못 지움
+
+            ssd.processCommand(new String[]{"E", "95", "10"});
+            output = Files.readString(Paths.get(SsdConstants.OUTPUT_FILE_PATH));
+            assertThat(output).isEqualTo(SsdConstants.ERROR); // 99 LBA 넘어서 못 자움
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
 }


### PR DESCRIPTION
## 📌 제목 (Title)
**[feature] erase 유효성 검사 추가**

---

## ✨ 주요 변경사항 (What’s changed?)
- 아래 내용 마저 구현했습니다.
![image](https://github.com/user-attachments/assets/0a232308-739b-4258-ace3-e13130c0d556)
`    void processCommand_삭제_유효성검사_걸러내는지_확인() { `

- 기존에 read, write 실행되는 방식처럼 Ssd 내부에서 erase도 부르도록 기능 추가했습니다.
`    void SsdEraserTest와_같은_테스트를_processCommand로_진행() { `
---

## 🧪 테스트 (Test Plan)

- [x] 테스트 코드 작성 또는 기존 테스트 통과 확인
- [x] 직접 실행해본 결과 스크린샷 or 설명 포함 (선택)
![image](https://github.com/user-attachments/assets/640e91a4-c595-4f7f-8420-b1f4de4dc835)

---


## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 작동함
- [x] 스타일 가이드/코딩 컨벤션을 따름
- [x] 필요한 경우 문서(README 등)를 업데이트함
- [x] 리뷰어가 이해하기 쉬운 설명이 포함됨


## 💬 기타 (Additional Notes)
