### PR TITLE
initFiles 기능 완료에 따른 기존 기능 삭제 + bufferClear 기능 분리

### DIFF
--- a/SsdDriver/src/main/java/BufferUtil.java
+++ b/SsdDriver/src/main/java/BufferUtil.java
@@ -54,7 +54,7 @@ public class BufferUtil {
         }
     }
 
-    private static void deleteBufferDirAndFiles() {
+    public static void deleteBufferDirAndFiles() {
         Path folder = Paths.get(SsdConstants.BUFFER_PATH);
         if (Files.exists(folder) && Files.isDirectory(folder)) {
             try (Stream<Path> walk = Files.walk(folder, FileVisitOption.FOLLOW_LINKS)) {
@@ -92,18 +92,18 @@ public class BufferUtil {
         }
     }
 
-    public static boolean existBufferFile(File bufferDir, int bufferNum) {
+    private static boolean existBufferFile(File bufferDir, int bufferNum) {
         final String bufferPrefix = getBufferFilePrefix(bufferNum);
         File[] bufferFiles = bufferDir.listFiles((dir, name) -> name.startsWith(bufferPrefix));
 
         return bufferFiles != null && bufferFiles.length > 0;
     }
 
-    public static String getBufferFilePrefix(int bufferNum) {
+    private static String getBufferFilePrefix(int bufferNum) {
         return bufferNum + "_";
     }
 
-    public static String getBufferDefaultFileName(int bufferNum) {
+    private static String getBufferDefaultFileName(int bufferNum) {
         return getBufferFilePrefix(bufferNum) + "empty";
     }
 }

--- a/SsdDriver/src/main/java/BufferUtil.java
+++ b/SsdDriver/src/main/java/BufferUtil.java
@@ -1,11 +1,11 @@
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Stream;
 
 public class BufferUtil {
 
@@ -55,6 +55,24 @@ public class BufferUtil {
     }
 
     private static void deleteBufferDirAndFiles() {
+        Path folder = Paths.get(SsdConstants.BUFFER_PATH);
+        if (Files.exists(folder) && Files.isDirectory(folder)) {
+            try (Stream<Path> walk = Files.walk(folder, FileVisitOption.FOLLOW_LINKS)) {
+                walk.sorted(Comparator.reverseOrder())
+                        .filter(path -> !path.equals(folder))
+                        .forEach(path -> {
+                            try {
+                                Files.delete(path);
+                            } catch (IOException e) {
+                                // ignore
+                            }
+
+                        });
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+
         File bufferDir = new File(SsdConstants.BUFFER_PATH);
         bufferDir.delete();
     }
@@ -70,14 +88,22 @@ public class BufferUtil {
     public static void checkAndCreateEmptyBufferFiles(File bufferDir) throws IOException {
         for (int bufferNum = 1; bufferNum <= SsdConstants.BUFFER_SIZE; bufferNum++) {
             if (existBufferFile(bufferDir, bufferNum)) continue;
-            Files.writeString(Paths.get(bufferDir.getPath(), SsdConstants.getBufferDefaultFileName(bufferNum)), "");
+            Files.writeString(Paths.get(bufferDir.getPath(), getBufferDefaultFileName(bufferNum)), "");
         }
     }
 
     public static boolean existBufferFile(File bufferDir, int bufferNum) {
-        final String bufferPrefix = SsdConstants.getBufferFilePrefix(bufferNum);
+        final String bufferPrefix = getBufferFilePrefix(bufferNum);
         File[] bufferFiles = bufferDir.listFiles((dir, name) -> name.startsWith(bufferPrefix));
 
         return bufferFiles != null && bufferFiles.length > 0;
+    }
+
+    public static String getBufferFilePrefix(int bufferNum) {
+        return bufferNum + "_";
+    }
+
+    public static String getBufferDefaultFileName(int bufferNum) {
+        return getBufferFilePrefix(bufferNum) + "empty";
     }
 }

--- a/SsdDriver/src/main/java/BufferUtil.java
+++ b/SsdDriver/src/main/java/BufferUtil.java
@@ -1,4 +1,7 @@
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,4 +43,41 @@ public class BufferUtil {
         return commandList;
     }
 
+    public static void clearBuffer() {
+        try {
+            deleteBufferDirAndFiles();
+
+            File bufferDir = checkAndCreateBufferDir();
+            checkAndCreateEmptyBufferFiles(bufferDir);
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    private static void deleteBufferDirAndFiles() {
+        File bufferDir = new File(SsdConstants.BUFFER_PATH);
+        bufferDir.delete();
+    }
+
+    public static File checkAndCreateBufferDir() {
+        File bufferDir = new File(SsdConstants.BUFFER_PATH);
+        if (!bufferDir.exists()) {
+            bufferDir.mkdirs();
+        }
+        return bufferDir;
+    }
+
+    public static void checkAndCreateEmptyBufferFiles(File bufferDir) throws IOException {
+        for (int bufferNum = 1; bufferNum <= SsdConstants.BUFFER_SIZE; bufferNum++) {
+            if (existBufferFile(bufferDir, bufferNum)) continue;
+            Files.writeString(Paths.get(bufferDir.getPath(), SsdConstants.getBufferDefaultFileName(bufferNum)), "");
+        }
+    }
+
+    public static boolean existBufferFile(File bufferDir, int bufferNum) {
+        final String bufferPrefix = SsdConstants.getBufferFilePrefix(bufferNum);
+        File[] bufferFiles = bufferDir.listFiles((dir, name) -> name.startsWith(bufferPrefix));
+
+        return bufferFiles != null && bufferFiles.length > 0;
+    }
 }

--- a/SsdDriver/src/main/java/Ssd.java
+++ b/SsdDriver/src/main/java/Ssd.java
@@ -22,7 +22,7 @@ public class Ssd {
         try  {
             initFiles();
         } catch (IOException e) {
-            // Ignore?
+            // ignore
         }
 
         if (!checkPreCondition(args)) {
@@ -40,12 +40,12 @@ public class Ssd {
     }
 
     void initFiles() throws IOException {
-        checkAndCreateOutputFile();
+        checkAndClearOutputFile();
         checkAndCreateNandFile();
         checkAndCreateBuffer();
     }
 
-    private void checkAndCreateOutputFile() throws IOException {
+    private void checkAndClearOutputFile() throws IOException {
         Files.writeString(Paths.get(SsdConstants.OUTPUT_FILE_PATH), "");
     }
 
@@ -60,25 +60,8 @@ public class Ssd {
     }
 
     private void checkAndCreateBuffer() throws IOException {
-        File bufferDir = new File(SsdConstants.BUFFER_DIR_NAME);
-        if (!bufferDir.exists()) {
-            bufferDir.mkdirs();
-            createEmptyBufferFiles(bufferDir);
-        }
-    }
-
-    private void createEmptyBufferFiles(File bufferDir) throws IOException {
-        for (int bufferNum = 1; bufferNum <= SsdConstants.BUFFER_SIZE; bufferNum++) {
-            if (existBufferFile(bufferDir, bufferNum)) continue;
-            Files.writeString(Paths.get(bufferDir.getPath(), SsdConstants.getBufferDefaultFileName(bufferNum)), "");
-        }
-    }
-
-    private boolean existBufferFile(File bufferDir, int bufferNum) {
-        final String bufferPrefix = SsdConstants.getBufferFilePrefix(bufferNum);
-        File[] bufferFiles = bufferDir.listFiles((dir, name) -> name.startsWith(bufferPrefix));
-
-        return bufferFiles != null && bufferFiles.length > 0;
+        File bufferDir = BufferUtil.checkAndCreateBufferDir();
+        BufferUtil.checkAndCreateEmptyBufferFiles(bufferDir);
     }
 
     private void processWriteCommand(String[] args) {

--- a/SsdDriver/src/main/java/SsdConstants.java
+++ b/SsdDriver/src/main/java/SsdConstants.java
@@ -6,9 +6,9 @@ public final class SsdConstants {
 
     public static final String SSD_NAND_FILE = "ssd_nand.txt";
     public static final String OUTPUT_FILE_PATH = "ssd_output.txt";
+    public static final String BUFFER_PATH = "buffer";
     public static final int BLOCK_SIZE = 10;
     public static final int BUFFER_SIZE = 5;
-    public static final String BUFFER_PATH = "buffer";
     public static final String DEFAULT_DATA = "0x00000000";
     public static final String ERROR = "ERROR";
 

--- a/SsdDriver/src/main/java/SsdConstants.java
+++ b/SsdDriver/src/main/java/SsdConstants.java
@@ -6,7 +6,6 @@ public final class SsdConstants {
 
     public static final String SSD_NAND_FILE = "ssd_nand.txt";
     public static final String OUTPUT_FILE_PATH = "ssd_output.txt";
-    public static final String BUFFER_DIR_NAME = "buffer";
     public static final int BLOCK_SIZE = 10;
     public static final int BUFFER_SIZE = 5;
     public static final String BUFFER_PATH = "buffer";

--- a/SsdDriver/src/main/java/SsdConstants.java
+++ b/SsdDriver/src/main/java/SsdConstants.java
@@ -6,8 +6,17 @@ public final class SsdConstants {
 
     public static final String SSD_NAND_FILE = "ssd_nand.txt";
     public static final String OUTPUT_FILE_PATH = "ssd_output.txt";
+    public static final String BUFFER_DIR_NAME = "buffer";
     public static final int BLOCK_SIZE = 10;
     public static final int BUFFER_SIZE = 5;
     public static final String DEFAULT_DATA = "0x00000000";
     public static final String ERROR = "ERROR";
+
+    public static String getBufferFilePrefix(int bufferNum) {
+        return bufferNum + "_";
+    }
+
+    public static String getBufferDefaultFileName(int bufferNum) {
+        return getBufferFilePrefix(bufferNum) + "empty";
+    }
 }

--- a/SsdDriver/src/main/java/SsdConstants.java
+++ b/SsdDriver/src/main/java/SsdConstants.java
@@ -11,12 +11,4 @@ public final class SsdConstants {
     public static final int BUFFER_SIZE = 5;
     public static final String DEFAULT_DATA = "0x00000000";
     public static final String ERROR = "ERROR";
-
-    public static String getBufferFilePrefix(int bufferNum) {
-        return bufferNum + "_";
-    }
-
-    public static String getBufferDefaultFileName(int bufferNum) {
-        return getBufferFilePrefix(bufferNum) + "empty";
-    }
 }

--- a/SsdDriver/src/main/java/SsdFlush.java
+++ b/SsdDriver/src/main/java/SsdFlush.java
@@ -1,10 +1,5 @@
 import java.io.IOException;
-import java.nio.file.FileVisitOption;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.*;
-import java.util.stream.Stream;
 
 public class SsdFlush {
 
@@ -20,34 +15,6 @@ public class SsdFlush {
             }
         }
 
-        initBuffer();
-    }
-
-    private void initBuffer() throws IOException {
-        Path folder = Paths.get("buffer");
-        if (Files.exists(folder) && Files.isDirectory(folder)) {
-            try (Stream<Path> walk = Files.walk(folder, FileVisitOption.FOLLOW_LINKS)) {
-                walk.sorted(Comparator.reverseOrder())
-                        .filter(path -> !path.equals(folder))
-                        .forEach(path -> {
-                            try {
-                                Files.delete(path);
-                            } catch (IOException e) {
-                                // ignore
-                            }
-
-                        });
-            }
-
-            try {
-                Files.createFile(folder.resolve("1_empty"));
-                Files.createFile(folder.resolve("2_empty"));
-                Files.createFile(folder.resolve("3_empty"));
-                Files.createFile(folder.resolve("4_empty"));
-                Files.createFile(folder.resolve("5_empty"));
-            } catch (IOException e) {
-                // ignore
-            }
-        }
+        BufferUtil.clearBuffer();
     }
 }

--- a/SsdDriver/src/main/java/SsdWriter.java
+++ b/SsdDriver/src/main/java/SsdWriter.java
@@ -1,21 +1,9 @@
 import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 public class SsdWriter {
 
-    public static final String DEFAULT_DATA = "0x00000000";
-    public static final int MAX_DATA_COUNT = 100;
-
     public void write(int address, String data) throws IOException {
-        checkFileAndWriteDefaultData();
         writeData(address, data);
-    }
-
-    private void checkFileAndWriteDefaultData() throws IOException {
-        File file = new File(SsdConstants.SSD_NAND_FILE);
-        if (file.exists()) return;
-        writeDefaultData();
     }
 
     private void writeData(long address, String data) throws IOException {
@@ -24,9 +12,5 @@ public class SsdWriter {
         raf.seek(address * SsdConstants.BLOCK_SIZE);
         raf.writeBytes(data);
         raf.close();
-    }
-
-    private void writeDefaultData() throws IOException {
-        Files.writeString(Paths.get(SsdConstants.SSD_NAND_FILE), DEFAULT_DATA.repeat(MAX_DATA_COUNT));
     }
 }

--- a/SsdDriver/src/test/java/SsdTest.java
+++ b/SsdDriver/src/test/java/SsdTest.java
@@ -28,7 +28,7 @@ class SsdTest {
     }
 
     @Test
-    void initFiles() {
+    void 실행_전_파일_정상_생성_확인() {
         Ssd ssd = spy(new Ssd());
 
         try {

--- a/SsdDriver/src/test/java/SsdTest.java
+++ b/SsdDriver/src/test/java/SsdTest.java
@@ -32,6 +32,20 @@ class SsdTest {
     }
 
     @Test
+    void buffer_폴더_및_하위_파일_있을_때_삭제_기능_확인() {
+        try {
+            File bufferDir = BufferUtil.checkAndCreateBufferDir();
+            BufferUtil.checkAndCreateEmptyBufferFiles(bufferDir);
+
+            BufferUtil.deleteBufferDirAndFiles();
+        } catch (Exception e) {
+            fail(e.getMessage());
+        }
+
+        assertFalse(new File("buffer").exists(), "Buffer directory should NOT exist");
+    }
+
+    @Test
     void initFiles_뒤_파일_정상_초기화_및_생성_확인() {
         Ssd ssd = spy(new Ssd());
 

--- a/SsdDriver/src/test/java/SsdWriterTest.java
+++ b/SsdDriver/src/test/java/SsdWriterTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -21,6 +22,7 @@ class SsdWriterTest {
     }
 
     @Test
+    @Disabled
     void 파일_Write시_파일이_없으면_초기화() throws Exception {
         // arrange
 


### PR DESCRIPTION
## 📌 제목 (Title)
**initFiles 기능 완료에 따른 기존 기능 삭제 + bufferClear 기능 분리**

---

## ✨ 주요 변경사항 (What’s changed?)
```
-- Ssd.java
    void initFiles() throws IOException {
        checkAndClearOutputFile();
        checkAndCreateNandFile();
        checkAndCreateBuffer();
    }
```
ssd의 initFiles에서 output, nand, buffer 파일을 생성합니다.
- output은 무조건 ""로 덮어씁니다. 또는 새로 만들어 덮어씁니다.
- nand는 있으면 놔두고, 없으면 새로 만들어 0x00000000으로 채웁니다. (기존 기능 writer에서 이관)
- buffer은 bufferUtil에 모든 기능이 있으며,
  - initFiles는 buffer 폴더 있으면 그대로, 없으면 새로 만든 뒤 -> 1_ ~ 5_ 에서 없는 게 발견되면 n_empty를 선택적으로 만듭니다.  (`checkAndCreateEmptyBufferFiles`)
  ```java
      private void checkAndCreateBuffer() throws IOException {
        File bufferDir = BufferUtil.checkAndCreateBufferDir();
        BufferUtil.checkAndCreateEmptyBufferFiles(bufferDir);
    }
  ```
  - 만약 flush가 사용하면, `clearBuffer` -> `deleteBufferDirAndFiles` + `checkAndCreateBufferDir` + `checkAndCreateEmptyBufferFiles` 순으로 초기화합니다. 
  ```java
      public static void clearBuffer() {
        try {
            deleteBufferDirAndFiles();

            File bufferDir = checkAndCreateBufferDir();
            checkAndCreateEmptyBufferFiles(bufferDir);
        } catch (Exception e) {
            // ignore
        }
    }
  ```

---

## 🧪 테스트 (Test Plan)

- [x] 테스트 코드 작성 또는 기존 테스트 통과 확인
![image](https://github.com/user-attachments/assets/964e4042-a0b4-4de0-9de9-d0fd1ac3924c)

- [x] 직접 실행해본 결과 스크린샷 or 설명 포함 (선택)
단, 아래는 disable 시켜뒀습니다. (더이상 writer에서 초기화 x)
```java
    @Test
    @Disabled
    void 파일_Write시_파일이_없으면_초기화() throws Exception {
        // arrange

        // act
        ssdWriter.write(3, "0x1234ABCD");
        RandomAccessFile raf = new RandomAccessFile(SsdConstants.SSD_NAND_FILE, "r");
        raf.seek(0);
        byte[] buf = new byte[SsdConstants.BLOCK_SIZE];
        raf.readFully(buf);
        raf.close();

        // assert
        assertThat(new String(buf)).isEqualTo("0x00000000");
    }
```
---


## ✅ 체크리스트 (Checklist)

- [x] 코드가 정상적으로 작동함
- [x] 스타일 가이드/코딩 컨벤션을 따름
- [x] 필요한 경우 문서(README 등)를 업데이트함
- [x] 리뷰어가 이해하기 쉬운 설명이 포함됨


## 💬 기타 (Additional Notes)
@dudalss-moon 님~ BufferUtil.clearBuffer()로 수정해둘게요! https://github.com/jae1-shin/BetterThanYesterdaySSD/pull/86#pullrequestreview-2920043483