### PR TITLE
[feature] ssd 버퍼컨트롤러 ignore, merge 구현

### DIFF
--- a/SsdDriver/src/main/java/BufferController.java
+++ b/SsdDriver/src/main/java/BufferController.java
@@ -1,29 +1,95 @@
+import java.io.IOException;
 import java.util.List;
+import java.util.ListIterator;
 
 public class BufferController {
-    List<Command> bufCmdList;
+    List<Command> buffer;
 
-    public void optimizeBuffer() {
+    public void processCommand(Command newCmd) throws IOException {
+        getBufferFromDisk();
+        flushBufferIfNeeded();
 
+        if (newCmd.type == CommandType.WRITE) {
+            applyIgnoreWrite(newCmd);
+        } else {
+            applyIgnoreErase(newCmd);
+        }
+
+        if (newCmd.type == CommandType.ERASE) {
+            applyMergeErase(newCmd);
+        }
     }
 
-    private void readBuffer() {
-
+    private void flushBufferIfNeeded() throws IOException {
+        if (buffer.size() != 5) return;
+        SsdFlush ssdFlush = new SsdFlush();
+        ssdFlush.plush();
+        getBufferFromDisk();
     }
 
-    private void ignoreWriteCommand() {
-
+    private void getBufferFromDisk() {
+        buffer = BufferUtil.getCommandList();
     }
 
-    private void ignoreEraseCommand() {
-
+    private void applyIgnoreWrite(Command newCmd) {
+        buffer.removeIf(cmd -> cmd.getType() == CommandType.WRITE && cmd.getLba() == newCmd.getLba());
+        buffer.add(newCmd);
     }
 
-    private void mergeEraseCommand() {
+    private void applyIgnoreErase(Command newCmd) {
+        int newStart = newCmd.getLba();
+        int newEnd = newCmd.getLba() + newCmd.getSize() - 1;
 
+        buffer.removeIf(cmd -> {
+            if (cmd.getType() == CommandType.WRITE) {
+                // Write 명령어의 LBA가 Erase 범위에 포함되면 삭제
+                return cmd.getLba() >= newStart && cmd.getLba() <= newEnd;
+            } else if (cmd.getType() == CommandType.ERASE) {
+                // 기존 Erase 명령어 범위가 새 Erase 범위와 겹치면 삭제
+                int start = cmd.getLba();
+                int end = cmd.getLba() + cmd.getSize() - 1;
+                return start >= newStart && end <= newEnd;
+            }
+            return false;
+        });
+
+        buffer.add(newCmd);
     }
 
-    public List<Command> getBufCmdList() {
-        return bufCmdList;
+    private void applyMergeErase(Command newCmd) {
+        if (buffer.size() < 2) return;
+
+        ListIterator<Command> iter = buffer.listIterator(buffer.size());
+        Command current = iter.previous();
+        Command previous = iter.previous();
+
+        if (current.getType() == CommandType.ERASE && previous.getType() == CommandType.ERASE) {
+            int start1 = previous.getLba();
+            int end1 = previous.getLba() + previous.getSize() - 1;
+            int start2 = current.getLba();
+            int end2 = current.getLba() + current.getSize() - 1;
+
+            // 두 Erase 명령어 범위가 인접하거나 겹치는지 확인
+            if ((start2 <= end1 + 1) || (start1 <= end2 + 1)) {
+                // 두 범위 합치기
+                int mergedStart = Math.min(start1, start2);
+                int mergedEnd = Math.max(end1, end2);
+                int mergedSize = mergedEnd - mergedStart + 1;
+
+                // Size는 10 이하인 경우 두 명령어 제거 후 합친 명령어 추가
+                if (mergedSize <= 10) {
+                    iter.remove();
+                    iter.next();
+                    iter.remove();
+                    Command merged = new Command(buffer.size() + 1, CommandType.ERASE, mergedStart, mergedSize, null,
+                            "E_" + mergedStart + "_" + mergedSize);
+                    buffer.add(merged);
+                }
+            }
+        }
+    }
+
+    public List<Command> getBuffer() {
+        return buffer;
     }
 }


### PR DESCRIPTION
## 📌 제목 (Title)

- ssd 버퍼컨트롤러 ignore, merge 구현

---

## ✨ 주요 변경사항 (What’s changed?)

- BufferController 클래스 기본 골격 수정
- buffer에서 command 가져와서 저장
- flush 체크
- ignore write, ignore erase, merge erase 구현
- 테스트 케이스 추가
---

## 🧪 테스트 (Test Plan)

- [x] 테스트 코드 작성 또는 기존 테스트 통과 확인
- [x] 직접 실행해본 결과 스크린샷 or 설명 포함 (선택)
![image](https://github.com/user-attachments/assets/b44b54a6-570b-43e3-99f9-c70d7e48a6d0)

---


## ✅ 체크리스트 (Checklist)

- [ ] 코드가 정상적으로 작동함
- [ ] 스타일 가이드/코딩 컨벤션을 따름
- [ ] 필요한 경우 문서(README 등)를 업데이트함
- [ ] 리뷰어가 이해하기 쉬운 설명이 포함됨


## 💬 기타 (Additional Notes)

- 코드 리뷰 시 참고할 만한 사항, 고민한 점 등을 자유롭게 작성
